### PR TITLE
Authentication is disabled by default

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,3 @@
-REF_SERVER_CORS_ORIGIN=http://localhost:4200
-REF_SERVER_PORT=8080
-REF_SERVER_EXPOSED_PORT=8080
 REF_SERVER_URL=http://localhost:8080
 ODH_BASE_URL=http://tourism.opendatahub.bz.it/api/
 ODH_TIMEOUT=120000

--- a/src/connectors/odh-connector.js
+++ b/src/connectors/odh-connector.js
@@ -19,6 +19,7 @@ const EVENT_SERIES_PATH = '../../data/event-series.data';
 const axiosOpts = {
   baseURL: process.env.ODH_BASE_URL,
   timeout: process.env.ODH_TIMEOUT,
+  headers: { 'Accept': 'application/json' }
 }
 
 function fetchEvents (request) {
@@ -149,8 +150,11 @@ async function fetch(path, request, transformFn) {
   let res;
 
   try {
-    console.log(`\n> Fetching data from ${process.env.ODH_BASE_URL+path}...`);
+    console.log(`\n> Fetching data from ${process.env.ODH_BASE_URL+path}`);
     res = await instance.get(path);
+
+    if(typeof res.data === 'string')
+      res.data = JSON.parse(res.data);
   }
   catch(error){
     handleConnectionError(error);
@@ -185,6 +189,12 @@ async function fetchMountainArea(request, field) {
     let areaPath = areaId ? SKIAREA_PATH+'/'+areaId : SKIAREA_PATH;
     let regionPath = areaId ? SKIAREGION_PATH+'/'+areaId : SKIAREGION_PATH;
     [ areaRes, regionRes] = await Promise.all([instance.get(areaPath), instance.get(regionPath)]);
+
+    if(typeof areaRes.data === 'string')
+      areaRes.data = JSON.parse(areaRes.data);
+
+    if(typeof regionRes.data === 'string')
+      regionRes.data = JSON.parse(regionRes.data);
   }
   catch(error) {
     handleConnectionError(error);
@@ -267,6 +277,9 @@ function fetchMountainSubResources(request, area, opts) {
     console.log(`> Fetching ${relationship} from ${process.env.ODH_BASE_URL+path}...`);
     return instance.get(path)
       .then( res => {
+        if(typeof res.data === 'string')
+          res.data = JSON.parse(res.data);
+
         if(res.status!==200 || !res.data)
           area[relationship] = [];
         else if('Items' in res.data)

--- a/src/server.js
+++ b/src/server.js
@@ -19,19 +19,25 @@ app.use( (req, res, next) => {
   next();
 });
 
-app.use(basicAuth({
-    authorizer: (username, password) => {
-      const userMatches = basicAuth.safeCompare(username, process.env.USERNAME);
-      const passwordMatches = basicAuth.safeCompare(password, process.env.PASSWORD);
-      return userMatches & passwordMatches;
-    },
-    unauthorizedResponse: (req, res) => {
-      console.log('Unauthorized request ' + process.env.REF_SERVER_URL + req.originalUrl);
-      return req.auth
-        ? errors.createJSON(errors.credentialsRejected)
-        : errors.createJSON(errors.noCredentials)
-    }
-}))
+if(process.env.AUTH_METHOD==='basic-auth') {
+  console.log("Server will run with BasicAuth enabled.")
+  app.use(basicAuth({
+      authorizer: (username, password) => {
+        const userMatches = basicAuth.safeCompare(username, process.env.USERNAME);
+        const passwordMatches = basicAuth.safeCompare(password, process.env.PASSWORD);
+        return userMatches & passwordMatches;
+      },
+      unauthorizedResponse: (req, res) => {
+        console.log('Unauthorized request ' + process.env.REF_SERVER_URL + req.originalUrl);
+        return req.auth
+          ? errors.createJSON(errors.credentialsRejected)
+          : errors.createJSON(errors.noCredentials)
+      }
+  }))
+}
+else{
+  console.log("Server will run without an authentication method.")
+}
 
 app.use( (req, res, next) => {
   res.setHeader('Content-Type', 'application/vnd.api+json');
@@ -56,5 +62,5 @@ app.get('*', (req, res) => {
 });
 
 http.createServer(app).listen(process.env.REF_SERVER_PORT, function () {
-  console.log('DestinationData API listening at %s', process.env.REF_SERVER_URL);
+  console.log('DestinationData server listening at %s', process.env.REF_SERVER_URL);
 })

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,7 +1,7 @@
 const utils = require('./utils');
 const axiosInstance = require('axios').create();
 
-require('custom-env').env();
+require('custom-env').env('test');
 
 describe(`Testing unknown route`, () => {
   test('Unknown route returns 404 NOT FOUND', () => {
@@ -13,38 +13,43 @@ describe(`Testing unknown route`, () => {
   });
 });
 
-describe(`Refuse request without authentication`, () => {
-  let status, data;
+if(process.env.AUTH_METHOD==='basic-auth') {
+  describe(`Refuse request without authentication`, () => {
+    let status, data;
 
-  beforeAll( () => {
-    return axiosInstance.get(process.env.REF_SERVER_URL+'/1.0/events')
-      .catch( res =>  ({data, status} = res.response) );
+    beforeAll( () => {
+      return axiosInstance.get(process.env.REF_SERVER_URL+'/1.0/events')
+        .catch( res =>  ({data, status} = res.response) );
+    });
+
+    test('Test HTTP Status 401 Unauthorized', () => {
+      if(process)
+      expect(status).toEqual(401);
+    });
+
+    test('Test error message title', () => {
+      expect(data.errors.length).toEqual(1);
+      expect(data.errors[0].title).toEqual("No credentials were provided.");
+    });
   });
 
-  test('Test HTTP Status 401 Unauthorized', () => {
-    expect(status).toEqual(401);
+  describe(`Refuse request with invalid username and password`, () => {
+    let status, message;
+  
+    beforeAll( () => {
+      return axiosInstance.get(process.env.REF_SERVER_URL+'/1.0/events', { auth: { username: 'me', password: 'mypassword' }})
+        .catch( res =>  ({data, status} = res.response) );
+    });
+  
+    test('Test HTTP Status 401 Unauthorized', () => {
+      expect(status).toEqual(401);
+    });
+  
+    test('Test error message title', () => {
+      expect(data.errors.length).toEqual(1);
+      expect(data.errors[0].title).toEqual("Credentials rejected.");
+    });
   });
+}
 
-  test('Test error message title', () => {
-    expect(data.errors.length).toEqual(1);
-    expect(data.errors[0].title).toEqual("No credentials were provided.");
-  });
-});
 
-describe(`Refuse request with invalid username and password`, () => {
-  let status, message;
-
-  beforeAll( () => {
-    return axiosInstance.get(process.env.REF_SERVER_URL+'/1.0/events', { auth: { username: 'me', password: 'mypassword' }})
-      .catch( res =>  ({data, status} = res.response) );
-  });
-
-  test('Test HTTP Status 401 Unauthorized', () => {
-    expect(status).toEqual(401);
-  });
-
-  test('Test error message title', () => {
-    expect(data.errors.length).toEqual(1);
-    expect(data.errors[0].title).toEqual("Credentials rejected.");
-  });
-});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-require('custom-env').env();
+require('custom-env').env('test');
 
 const TIMEOUT = 300000;
 const AUTH = {


### PR DESCRIPTION
The Basic Authentication feature is now disabled by default on the server.

The environment variable that controls this behavior is `AUTH_METHOD`. If set to `basic-auth`, it turns the basic authentication on. For any other value, it turns it off.

I also adjusted the tests so they are aware of the expected behavior w.r.t. authentication. You will see that I added a `.env.test` file to control environment values for testing.

Lastly, I made some small changes to adjust to the new behavior of the open data hub api, which now return strings instead of JSON in some situations.