### PR TITLE
Bugfix: Removed address from mountain areas

### DIFF
--- a/src/transformers/odh2alpinebits/mountainarea.transform.js
+++ b/src/transformers/odh2alpinebits/mountainarea.transform.js
@@ -100,7 +100,6 @@ function transformMountainArea(originalObject, included = {}, request) {
   Object.assign(attributes, utils.transformBasicProperties(source));
 
   attributes.howToArrive = utils.transformHowToArrive(source.Detail);
-  attributes.address = utils.transformAddress(source.ContactInfos, ['city','country','zipcode']);
 
   attributes.minAltitude = source.AltitudeFrom || null;
   attributes.maxAltitude = source.AltitudeTo || null;

--- a/src/transformers/odh2alpinebits/templates.js
+++ b/src/transformers/odh2alpinebits/templates.js
@@ -258,7 +258,6 @@ const resources = {
       shortName: null,
       description: null,
       url: null,
-      address: null,
       geometries: null,
       howToArrive: null,
       openingHours: null,

--- a/src/validator/schemas/README.md
+++ b/src/validator/schemas/README.md
@@ -1,6 +1,6 @@
-# AlpineBits DestinationData: Examples
+# AlpineBits DestinationData: Schemas
 
-This repository contains a list of JSON files containing [JSON Schemas](https://json-schema.org/) for each endpoint on an AlpineBits Destination data server.
+This folder contains a list of JSON files containing [JSON Schemas](https://json-schema.org/) for each endpoint on an AlpineBits Destination data server.
 
 The name of each file refer to the endpoints they apply to, for instance:
 

--- a/src/validator/schemas/README.md
+++ b/src/validator/schemas/README.md
@@ -1,0 +1,62 @@
+# AlpineBits DestinationData: Examples
+
+This repository contains a list of JSON files containing [JSON Schemas](https://json-schema.org/) for each endpoint on an AlpineBits Destination data server.
+
+The name of each file refer to the endpoints they apply to, for instance:
+
+* the file `mediaobjects.schema.json` the JSON Schema for validating messages of the endpoint `/1.0/mediaObjects`
+
+* the file `agetns.id.schema.json` the JSON Schema for validating messages of the endpoint `/1.0/agetns/:id`
+
+* the file `mountainareas.id.areaowner.schema.json` the JSON Schema for validating messages of the endpoint `/1.0/mountainAreas/:id/areaOwner`
+
+The following table correlates each file to its specific endpoint:
+
+| File name | Endpoint |
+| --------- | -------- |
+| base.endpoint.schema.json | /1.0 |
+| agents.schema.json | /1.0/agents |
+| agents.id.schema.json | /1.0/agents/:id |
+| agents.id.multimediadescriptions.schema.json | /1.0/agents/:id/multimediaDescriptions |
+| events.schema.json | /1.0/events |
+| events.id.schema.json | /1.0/events/:id |
+| events.id.contributors.schema.json | /1.0/events/:id/contributors |
+| events.id.multimediadescriptions.schema.json | /1.0/events/:id/multimediaDescriptions |
+| events.id.organizers.schema.json | /1.0/events/:id/organizers |
+| events.id.publisher.schema.json | /1.0/events/:id/publisher |
+| events.id.series.schema.json | /1.0/events/:id/series |
+| events.id.sponsors.schema.json | /1.0/events/:id/sponsors |
+| events.id.subevents.schema.json | /1.0/events/:id/subEvents |
+| events.id.venues.schema.json | /1.0/events/:id/venues |
+| eventseries.schema.json | /1.0/eventSeries |
+| eventseries.id.schema.json | /1.0/eventSeries/:id |
+| eventseries.id.editions.schema.json | /1.0/eventSeries/:id/editions |
+| eventseries.id.multimediadescriptions.schema.json | /1.0/eventSeries/:id/multimediaDescriptions |
+| lifts.schema.json | /1.0/lifts |
+| lifts.id.schema.json | /1.0/lifts/:id |
+| lifts.id.connections.schema.json | /1.0/lifts/:id/connections |
+| lifts.id.multimediadescriptions.schema.json | /1.0/lifts/:id/multimediaDescriptions |
+| mediaobjects.schema.json | /1.0/mediaObjects |
+| mediaobjects.id.schema.json | /1.0/mediaObjects/:id |
+| mediaobjects.id.copyrightowner.schema.json | /1.0/mediaObjects/:id/copyrightOwner |
+| mountainareas.id.areaowner.schema.json | /1.0/mountainAreas/:id/areaOwner |
+| mountainareas.schema.json | /1.0/mountainAreas |
+| mountainareas.id.schema.json | /1.0/mountainAreas/:id |
+| mountainareas.id.connections.schema.json | /1.0/mountainAreas/:id/connections |
+| mountainareas.id.lifts.schema.json | /1.0/mountainAreas/:id/lifts |
+| mountainareas.id.multimediadescriptions.schema.json | /1.0/mountainAreas/:id/multimediaDescriptions  |
+| mountainareas.id.snowparks.schema.json | /1.0/mountainAreas/:id/snowparks |
+| mountainareas.id.subareas.schema.json | /1.0/mountainAreas/:id/subAreas |
+| mountainareas.id.trails.schema.json | /1.0/mountainAreas/:id/trails |
+| snowparks.schema.json | /1.0/snowparks |
+| snowparks.id.schema.json | /1.0/snowparks/:id |
+| snowparks.id.connections.schema.json | /1.0/snowparks/:id/connections |
+| snowparks.id.multimediadescriptions.schema.json | /1.0/snowparks/:id/multimediaDescriptions |
+| trails.schema.json | /1.0/trails |
+| trails.id.schema.json | /1.0/trails/:id |
+| trails.id.connections.schema.json | /1.0/trails/:id/connections |
+| trails.id.multimediadescriptions.schema.json | /1.0/trails/:id/multimediaDescriptions |
+| venues.schema.json | /1.0/venues |
+| venues.id.schema.json | /1.0/venues/:id |
+| venues.id.multimediadescriptions.schema.json | /1.0/venues/:id/multimediaDescriptions |
+

--- a/src/validator/schemas/agents.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/agents.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/agents.id.schema.json
+++ b/src/validator/schemas/agents.id.schema.json
@@ -69,21 +69,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -117,11 +123,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -194,6 +203,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -211,28 +221,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -274,6 +262,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -297,6 +307,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -368,70 +379,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -440,6 +460,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -463,6 +484,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -482,6 +504,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -504,6 +527,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -527,6 +551,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -553,6 +578,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -579,6 +605,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -625,6 +652,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -730,6 +758,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1045,6 +1074,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1088,11 +1118,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1127,25 +1160,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1169,6 +1207,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1201,6 +1242,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1224,11 +1268,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1275,19 +1322,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1335,8 +1387,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/agents.schema.json
+++ b/src/validator/schemas/agents.schema.json
@@ -98,21 +98,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -146,11 +152,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -223,6 +232,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -240,28 +250,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -303,6 +291,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -326,6 +336,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -397,70 +408,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -469,6 +489,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -492,6 +513,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -511,6 +533,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -533,6 +556,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -556,6 +580,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -582,6 +607,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -608,6 +634,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -654,6 +681,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -759,6 +787,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1074,6 +1103,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1117,11 +1147,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1156,25 +1189,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1198,6 +1236,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1230,6 +1271,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1253,11 +1297,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1304,19 +1351,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1364,8 +1416,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/events.id.contributors.schema.json
+++ b/src/validator/schemas/events.id.contributors.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1135,25 +1168,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1177,6 +1215,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1209,6 +1250,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1232,11 +1276,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1283,19 +1330,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1343,8 +1395,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/events.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/events.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/events.id.organizers.schema.json
+++ b/src/validator/schemas/events.id.organizers.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1135,25 +1168,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1177,6 +1215,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1209,6 +1250,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1232,11 +1276,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1283,19 +1330,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1343,8 +1395,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/events.id.publisher.schema.json
+++ b/src/validator/schemas/events.id.publisher.schema.json
@@ -69,21 +69,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -117,11 +123,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -194,6 +203,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -211,28 +221,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -274,6 +262,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -297,6 +307,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -368,70 +379,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -440,6 +460,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -463,6 +484,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -482,6 +504,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -504,6 +527,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -527,6 +551,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -553,6 +578,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -579,6 +605,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -625,6 +652,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -730,6 +758,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1045,6 +1074,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1088,11 +1118,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1127,25 +1160,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1169,6 +1207,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1201,6 +1242,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1224,11 +1268,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1275,19 +1322,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1335,8 +1387,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/events.id.schema.json
+++ b/src/validator/schemas/events.id.schema.json
@@ -117,21 +117,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -165,11 +171,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -242,6 +251,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -259,28 +269,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -322,6 +310,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -345,6 +355,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -416,70 +427,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -488,6 +508,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -511,6 +532,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -530,6 +552,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -552,6 +575,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -575,6 +599,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -601,6 +626,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -627,6 +653,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -673,6 +700,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -778,6 +806,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1093,6 +1122,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1136,11 +1166,14 @@
     },
     "events": {
       "type": "object",
+      "description": "A resource representing an event, something that is planned to happen at a particular place and time, organized by an agent for a particular purpose, and is of interest to a general audience.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "events"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1180,15 +1213,19 @@
               "type": "object",
               "properties": {
                 "capacity": {
+                  "description": "An integer representing the total number of individuals that can attend the event.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "endDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to end.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "startDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to start.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "status": {
+                  "description": "A string representing the current status of the event.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1258,20 +1295,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "contributors": {
+              "description": "An object representing references to agent resources, which identifies the agents expected to participate in the event, such as a speaker who will give a talk or a musician who will perform at a concert.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1295,6 +1328,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1327,22 +1363,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1366,6 +1400,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1398,22 +1435,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "organizers": {
+              "description": "An object representing references to agent resources identifying the persons or organizations responsible for organizing the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1473,6 +1508,7 @@
               ]
             },
             "publisher": {
+              "description": "An object representing a reference to an agent resource who originally provided the data about the event. The publisher is not the organization who manages the system where the data was originally inserted, but the organization actually provided the data.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1534,6 +1570,7 @@
               ]
             },
             "series": {
+              "description": "An object representing a reference to an event series resource of which the event is an edition of.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1601,18 +1638,13 @@
               ]
             },
             "sponsors": {
+              "description": "An object representing references to agent resources identifying the persons or organizations who are sponsoring the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1636,6 +1668,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1668,22 +1703,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subEvents": {
+              "description": "An object representing references to event resources identifying the parts of the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1707,6 +1740,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1739,22 +1775,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "venues": {
+              "description": "An object representing references to venue resources identifying where the event will happen.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1833,11 +1867,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1872,25 +1909,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1914,6 +1956,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1946,6 +1991,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1969,11 +2017,14 @@
     },
     "eventSeries": {
       "type": "object",
+      "description": "A resource representing a series of event recurrent in time.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "eventSeries"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2013,6 +2064,7 @@
               "type": "object",
               "properties": {
                 "frequency": {
+                  "description": "A string representing how often editions of the event series are organized according to an enumeration of possible values.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -2038,20 +2090,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "editions": {
+              "description": "An object representing references to the event resources that are editions of the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2075,6 +2123,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2107,22 +2158,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2146,6 +2195,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2178,6 +2230,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2201,11 +2256,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2252,19 +2310,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2312,8 +2375,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2400,11 +2465,14 @@
     },
     "venues": {
       "type": "object",
+      "description": "A resource representing a venue, a place that may host an event.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "venues"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2444,12 +2512,15 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the venue.",
                   "$ref": "#/definitions/address"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the venue in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the venue.",
                   "$ref": "#/definitions/text"
                 }
               }
@@ -2458,20 +2529,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the venue.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2495,6 +2562,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2527,6 +2597,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/events.id.series.schema.json
+++ b/src/validator/schemas/events.id.series.schema.json
@@ -85,21 +85,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -133,11 +139,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -210,6 +219,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -227,28 +237,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -290,6 +278,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -313,6 +323,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -384,70 +395,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -456,6 +476,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -479,6 +500,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -498,6 +520,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -520,6 +543,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -543,6 +567,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -569,6 +594,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -595,6 +621,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -641,6 +668,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -746,6 +774,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1061,6 +1090,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1104,11 +1134,14 @@
     },
     "eventSeries": {
       "type": "object",
+      "description": "A resource representing a series of event recurrent in time.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "eventSeries"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1148,6 +1181,7 @@
               "type": "object",
               "properties": {
                 "frequency": {
+                  "description": "A string representing how often editions of the event series are organized according to an enumeration of possible values.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1173,20 +1207,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "editions": {
+              "description": "An object representing references to the event resources that are editions of the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1210,6 +1240,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1242,22 +1275,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1281,6 +1312,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1313,6 +1347,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1336,11 +1373,14 @@
     },
     "events": {
       "type": "object",
+      "description": "A resource representing an event, something that is planned to happen at a particular place and time, organized by an agent for a particular purpose, and is of interest to a general audience.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "events"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1380,15 +1420,19 @@
               "type": "object",
               "properties": {
                 "capacity": {
+                  "description": "An integer representing the total number of individuals that can attend the event.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "endDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to end.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "startDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to start.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "status": {
+                  "description": "A string representing the current status of the event.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1458,20 +1502,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "contributors": {
+              "description": "An object representing references to agent resources, which identifies the agents expected to participate in the event, such as a speaker who will give a talk or a musician who will perform at a concert.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1495,6 +1535,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1527,22 +1570,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1566,6 +1607,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1598,22 +1642,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "organizers": {
+              "description": "An object representing references to agent resources identifying the persons or organizations responsible for organizing the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1673,6 +1715,7 @@
               ]
             },
             "publisher": {
+              "description": "An object representing a reference to an agent resource who originally provided the data about the event. The publisher is not the organization who manages the system where the data was originally inserted, but the organization actually provided the data.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1734,6 +1777,7 @@
               ]
             },
             "series": {
+              "description": "An object representing a reference to an event series resource of which the event is an edition of.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1801,18 +1845,13 @@
               ]
             },
             "sponsors": {
+              "description": "An object representing references to agent resources identifying the persons or organizations who are sponsoring the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1836,6 +1875,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1868,22 +1910,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subEvents": {
+              "description": "An object representing references to event resources identifying the parts of the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1907,6 +1947,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1939,22 +1982,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "venues": {
+              "description": "An object representing references to venue resources identifying where the event will happen.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2033,11 +2074,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2084,19 +2128,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2144,8 +2193,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/events.id.sponsors.schema.json
+++ b/src/validator/schemas/events.id.sponsors.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1135,25 +1168,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1177,6 +1215,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1209,6 +1250,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1232,11 +1276,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1283,19 +1330,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1343,8 +1395,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/events.id.subevents.schema.json
+++ b/src/validator/schemas/events.id.subevents.schema.json
@@ -125,21 +125,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -173,11 +179,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -250,6 +259,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -267,28 +277,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -330,6 +318,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -353,6 +363,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -424,70 +435,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -496,6 +516,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -519,6 +540,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -538,6 +560,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -560,6 +583,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -583,6 +607,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -609,6 +634,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -635,6 +661,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -681,6 +708,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -786,6 +814,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1101,6 +1130,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1144,11 +1174,14 @@
     },
     "events": {
       "type": "object",
+      "description": "A resource representing an event, something that is planned to happen at a particular place and time, organized by an agent for a particular purpose, and is of interest to a general audience.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "events"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1188,15 +1221,19 @@
               "type": "object",
               "properties": {
                 "capacity": {
+                  "description": "An integer representing the total number of individuals that can attend the event.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "endDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to end.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "startDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to start.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "status": {
+                  "description": "A string representing the current status of the event.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1266,20 +1303,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "contributors": {
+              "description": "An object representing references to agent resources, which identifies the agents expected to participate in the event, such as a speaker who will give a talk or a musician who will perform at a concert.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1303,6 +1336,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1335,22 +1371,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1374,6 +1408,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1406,22 +1443,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "organizers": {
+              "description": "An object representing references to agent resources identifying the persons or organizations responsible for organizing the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1481,6 +1516,7 @@
               ]
             },
             "publisher": {
+              "description": "An object representing a reference to an agent resource who originally provided the data about the event. The publisher is not the organization who manages the system where the data was originally inserted, but the organization actually provided the data.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1542,6 +1578,7 @@
               ]
             },
             "series": {
+              "description": "An object representing a reference to an event series resource of which the event is an edition of.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1609,18 +1646,13 @@
               ]
             },
             "sponsors": {
+              "description": "An object representing references to agent resources identifying the persons or organizations who are sponsoring the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1644,6 +1676,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1676,22 +1711,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subEvents": {
+              "description": "An object representing references to event resources identifying the parts of the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1715,6 +1748,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1747,22 +1783,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "venues": {
+              "description": "An object representing references to venue resources identifying where the event will happen.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1841,11 +1875,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1880,25 +1917,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1922,6 +1964,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1954,6 +1999,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1977,11 +2025,14 @@
     },
     "eventSeries": {
       "type": "object",
+      "description": "A resource representing a series of event recurrent in time.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "eventSeries"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2021,6 +2072,7 @@
               "type": "object",
               "properties": {
                 "frequency": {
+                  "description": "A string representing how often editions of the event series are organized according to an enumeration of possible values.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -2046,20 +2098,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "editions": {
+              "description": "An object representing references to the event resources that are editions of the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2083,6 +2131,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2115,22 +2166,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2154,6 +2203,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2186,6 +2238,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2209,11 +2264,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2260,19 +2318,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2320,8 +2383,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2408,11 +2473,14 @@
     },
     "venues": {
       "type": "object",
+      "description": "A resource representing a venue, a place that may host an event.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "venues"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2452,12 +2520,15 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the venue.",
                   "$ref": "#/definitions/address"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the venue in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the venue.",
                   "$ref": "#/definitions/text"
                 }
               }
@@ -2466,20 +2537,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the venue.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2503,6 +2570,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2535,6 +2605,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/events.id.venues.schema.json
+++ b/src/validator/schemas/events.id.venues.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "venues": {
       "type": "object",
+      "description": "A resource representing a venue, a place that may host an event.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "venues"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1140,12 +1173,15 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the venue.",
                   "$ref": "#/definitions/address"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the venue in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the venue.",
                   "$ref": "#/definitions/text"
                 }
               }
@@ -1154,20 +1190,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the venue.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1191,6 +1223,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1223,6 +1258,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1246,11 +1284,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1297,19 +1338,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1357,8 +1403,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/events.schema.json
+++ b/src/validator/schemas/events.schema.json
@@ -146,21 +146,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -194,11 +200,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -271,6 +280,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -288,28 +298,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -351,6 +339,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -374,6 +384,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -445,70 +456,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -517,6 +537,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -540,6 +561,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -559,6 +581,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -581,6 +604,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -604,6 +628,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -630,6 +655,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -656,6 +682,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -702,6 +729,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -807,6 +835,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1122,6 +1151,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1165,11 +1195,14 @@
     },
     "events": {
       "type": "object",
+      "description": "A resource representing an event, something that is planned to happen at a particular place and time, organized by an agent for a particular purpose, and is of interest to a general audience.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "events"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1209,15 +1242,19 @@
               "type": "object",
               "properties": {
                 "capacity": {
+                  "description": "An integer representing the total number of individuals that can attend the event.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "endDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to end.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "startDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to start.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "status": {
+                  "description": "A string representing the current status of the event.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1287,20 +1324,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "contributors": {
+              "description": "An object representing references to agent resources, which identifies the agents expected to participate in the event, such as a speaker who will give a talk or a musician who will perform at a concert.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1324,6 +1357,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1356,22 +1392,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1395,6 +1429,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1427,22 +1464,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "organizers": {
+              "description": "An object representing references to agent resources identifying the persons or organizations responsible for organizing the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1502,6 +1537,7 @@
               ]
             },
             "publisher": {
+              "description": "An object representing a reference to an agent resource who originally provided the data about the event. The publisher is not the organization who manages the system where the data was originally inserted, but the organization actually provided the data.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1563,6 +1599,7 @@
               ]
             },
             "series": {
+              "description": "An object representing a reference to an event series resource of which the event is an edition of.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1630,18 +1667,13 @@
               ]
             },
             "sponsors": {
+              "description": "An object representing references to agent resources identifying the persons or organizations who are sponsoring the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1665,6 +1697,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1697,22 +1732,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subEvents": {
+              "description": "An object representing references to event resources identifying the parts of the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1736,6 +1769,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1768,22 +1804,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "venues": {
+              "description": "An object representing references to venue resources identifying where the event will happen.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1862,11 +1896,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1901,25 +1938,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1943,6 +1985,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1975,6 +2020,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1998,11 +2046,14 @@
     },
     "eventSeries": {
       "type": "object",
+      "description": "A resource representing a series of event recurrent in time.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "eventSeries"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2042,6 +2093,7 @@
               "type": "object",
               "properties": {
                 "frequency": {
+                  "description": "A string representing how often editions of the event series are organized according to an enumeration of possible values.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -2067,20 +2119,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "editions": {
+              "description": "An object representing references to the event resources that are editions of the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2104,6 +2152,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2136,22 +2187,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2175,6 +2224,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2207,6 +2259,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2230,11 +2285,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2281,19 +2339,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2341,8 +2404,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2429,11 +2494,14 @@
     },
     "venues": {
       "type": "object",
+      "description": "A resource representing a venue, a place that may host an event.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "venues"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2473,12 +2541,15 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the venue.",
                   "$ref": "#/definitions/address"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the venue in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the venue.",
                   "$ref": "#/definitions/text"
                 }
               }
@@ -2487,20 +2558,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the venue.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2524,6 +2591,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2556,6 +2626,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/eventseries.id.editions.schema.json
+++ b/src/validator/schemas/eventseries.id.editions.schema.json
@@ -125,21 +125,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -173,11 +179,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -250,6 +259,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -267,28 +277,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -330,6 +318,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -353,6 +363,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -424,70 +435,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -496,6 +516,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -519,6 +540,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -538,6 +560,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -560,6 +583,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -583,6 +607,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -609,6 +634,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -635,6 +661,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -681,6 +708,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -786,6 +814,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1101,6 +1130,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1144,11 +1174,14 @@
     },
     "events": {
       "type": "object",
+      "description": "A resource representing an event, something that is planned to happen at a particular place and time, organized by an agent for a particular purpose, and is of interest to a general audience.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "events"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1188,15 +1221,19 @@
               "type": "object",
               "properties": {
                 "capacity": {
+                  "description": "An integer representing the total number of individuals that can attend the event.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "endDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to end.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "startDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to start.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "status": {
+                  "description": "A string representing the current status of the event.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1266,20 +1303,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "contributors": {
+              "description": "An object representing references to agent resources, which identifies the agents expected to participate in the event, such as a speaker who will give a talk or a musician who will perform at a concert.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1303,6 +1336,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1335,22 +1371,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1374,6 +1408,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1406,22 +1443,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "organizers": {
+              "description": "An object representing references to agent resources identifying the persons or organizations responsible for organizing the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1481,6 +1516,7 @@
               ]
             },
             "publisher": {
+              "description": "An object representing a reference to an agent resource who originally provided the data about the event. The publisher is not the organization who manages the system where the data was originally inserted, but the organization actually provided the data.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1542,6 +1578,7 @@
               ]
             },
             "series": {
+              "description": "An object representing a reference to an event series resource of which the event is an edition of.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1609,18 +1646,13 @@
               ]
             },
             "sponsors": {
+              "description": "An object representing references to agent resources identifying the persons or organizations who are sponsoring the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1644,6 +1676,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1676,22 +1711,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subEvents": {
+              "description": "An object representing references to event resources identifying the parts of the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1715,6 +1748,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1747,22 +1783,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "venues": {
+              "description": "An object representing references to venue resources identifying where the event will happen.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1841,11 +1875,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1880,25 +1917,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1922,6 +1964,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1954,6 +1999,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1977,11 +2025,14 @@
     },
     "eventSeries": {
       "type": "object",
+      "description": "A resource representing a series of event recurrent in time.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "eventSeries"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2021,6 +2072,7 @@
               "type": "object",
               "properties": {
                 "frequency": {
+                  "description": "A string representing how often editions of the event series are organized according to an enumeration of possible values.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -2046,20 +2098,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "editions": {
+              "description": "An object representing references to the event resources that are editions of the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2083,6 +2131,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2115,22 +2166,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2154,6 +2203,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2186,6 +2238,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2209,11 +2264,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2260,19 +2318,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2320,8 +2383,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2408,11 +2473,14 @@
     },
     "venues": {
       "type": "object",
+      "description": "A resource representing a venue, a place that may host an event.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "venues"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2452,12 +2520,15 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the venue.",
                   "$ref": "#/definitions/address"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the venue in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the venue.",
                   "$ref": "#/definitions/text"
                 }
               }
@@ -2466,20 +2537,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the venue.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2503,6 +2570,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2535,6 +2605,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/eventseries.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/eventseries.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/eventseries.id.schema.json
+++ b/src/validator/schemas/eventseries.id.schema.json
@@ -85,21 +85,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -133,11 +139,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -210,6 +219,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -227,28 +237,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -290,6 +278,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -313,6 +323,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -384,70 +395,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -456,6 +476,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -479,6 +500,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -498,6 +520,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -520,6 +543,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -543,6 +567,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -569,6 +594,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -595,6 +621,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -641,6 +668,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -746,6 +774,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1061,6 +1090,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1104,11 +1134,14 @@
     },
     "eventSeries": {
       "type": "object",
+      "description": "A resource representing a series of event recurrent in time.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "eventSeries"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1148,6 +1181,7 @@
               "type": "object",
               "properties": {
                 "frequency": {
+                  "description": "A string representing how often editions of the event series are organized according to an enumeration of possible values.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1173,20 +1207,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "editions": {
+              "description": "An object representing references to the event resources that are editions of the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1210,6 +1240,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1242,22 +1275,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1281,6 +1312,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1313,6 +1347,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1336,11 +1373,14 @@
     },
     "events": {
       "type": "object",
+      "description": "A resource representing an event, something that is planned to happen at a particular place and time, organized by an agent for a particular purpose, and is of interest to a general audience.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "events"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1380,15 +1420,19 @@
               "type": "object",
               "properties": {
                 "capacity": {
+                  "description": "An integer representing the total number of individuals that can attend the event.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "endDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to end.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "startDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to start.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "status": {
+                  "description": "A string representing the current status of the event.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1458,20 +1502,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "contributors": {
+              "description": "An object representing references to agent resources, which identifies the agents expected to participate in the event, such as a speaker who will give a talk or a musician who will perform at a concert.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1495,6 +1535,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1527,22 +1570,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1566,6 +1607,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1598,22 +1642,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "organizers": {
+              "description": "An object representing references to agent resources identifying the persons or organizations responsible for organizing the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1673,6 +1715,7 @@
               ]
             },
             "publisher": {
+              "description": "An object representing a reference to an agent resource who originally provided the data about the event. The publisher is not the organization who manages the system where the data was originally inserted, but the organization actually provided the data.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1734,6 +1777,7 @@
               ]
             },
             "series": {
+              "description": "An object representing a reference to an event series resource of which the event is an edition of.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1801,18 +1845,13 @@
               ]
             },
             "sponsors": {
+              "description": "An object representing references to agent resources identifying the persons or organizations who are sponsoring the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1836,6 +1875,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1868,22 +1910,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subEvents": {
+              "description": "An object representing references to event resources identifying the parts of the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1907,6 +1947,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1939,22 +1982,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "venues": {
+              "description": "An object representing references to venue resources identifying where the event will happen.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2033,11 +2074,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2084,19 +2128,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2144,8 +2193,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/eventseries.schema.json
+++ b/src/validator/schemas/eventseries.schema.json
@@ -114,21 +114,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -162,11 +168,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -239,6 +248,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -256,28 +266,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -319,6 +307,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -342,6 +352,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -413,70 +424,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -485,6 +505,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -508,6 +529,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -527,6 +549,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -549,6 +572,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -572,6 +596,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -598,6 +623,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -624,6 +650,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -670,6 +697,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -775,6 +803,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1090,6 +1119,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1133,11 +1163,14 @@
     },
     "eventSeries": {
       "type": "object",
+      "description": "A resource representing a series of event recurrent in time.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "eventSeries"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1177,6 +1210,7 @@
               "type": "object",
               "properties": {
                 "frequency": {
+                  "description": "A string representing how often editions of the event series are organized according to an enumeration of possible values.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1202,20 +1236,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "editions": {
+              "description": "An object representing references to the event resources that are editions of the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1239,6 +1269,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1271,22 +1304,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event series.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1310,6 +1341,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1342,6 +1376,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1365,11 +1402,14 @@
     },
     "events": {
       "type": "object",
+      "description": "A resource representing an event, something that is planned to happen at a particular place and time, organized by an agent for a particular purpose, and is of interest to a general audience.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "events"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1409,15 +1449,19 @@
               "type": "object",
               "properties": {
                 "capacity": {
+                  "description": "An integer representing the total number of individuals that can attend the event.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "endDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to end.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "startDate": {
+                  "description": "A string, formatted as a date or date-time string, representing when the event is supposed to start.",
                   "$ref": "#/definitions/optionalDateOrDateTime"
                 },
                 "status": {
+                  "description": "A string representing the current status of the event.",
                   "oneOf": [
                     {
                       "type": "null"
@@ -1487,20 +1531,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "contributors": {
+              "description": "An object representing references to agent resources, which identifies the agents expected to participate in the event, such as a speaker who will give a talk or a musician who will perform at a concert.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1524,6 +1564,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1556,22 +1599,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1595,6 +1636,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1627,22 +1671,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "organizers": {
+              "description": "An object representing references to agent resources identifying the persons or organizations responsible for organizing the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1702,6 +1744,7 @@
               ]
             },
             "publisher": {
+              "description": "An object representing a reference to an agent resource who originally provided the data about the event. The publisher is not the organization who manages the system where the data was originally inserted, but the organization actually provided the data.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1763,6 +1806,7 @@
               ]
             },
             "series": {
+              "description": "An object representing a reference to an event series resource of which the event is an edition of.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1830,18 +1874,13 @@
               ]
             },
             "sponsors": {
+              "description": "An object representing references to agent resources identifying the persons or organizations who are sponsoring the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1865,6 +1904,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1897,22 +1939,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subEvents": {
+              "description": "An object representing references to event resources identifying the parts of the event.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1936,6 +1976,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1968,22 +2011,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "venues": {
+              "description": "An object representing references to venue resources identifying where the event will happen.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2062,11 +2103,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2113,19 +2157,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2173,8 +2222,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/lifts.id.connections.schema.json
+++ b/src/validator/schemas/lifts.id.connections.schema.json
@@ -166,21 +166,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -214,11 +220,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -291,6 +300,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -308,28 +318,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -371,6 +359,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -394,6 +404,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -465,70 +476,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -537,6 +557,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -560,6 +581,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -579,6 +601,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -601,6 +624,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -624,6 +648,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -650,6 +675,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -676,6 +702,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -722,6 +749,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -827,6 +855,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1142,6 +1171,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1185,11 +1215,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1229,30 +1262,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1261,20 +1303,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1301,6 +1339,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1333,22 +1374,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1372,6 +1411,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1404,6 +1446,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1427,11 +1472,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1471,30 +1519,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1503,8 +1560,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1572,18 +1631,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1610,6 +1664,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1642,22 +1699,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1681,6 +1736,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1713,22 +1771,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1752,6 +1808,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1784,22 +1843,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1823,6 +1880,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1855,22 +1915,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1894,6 +1952,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1926,22 +1987,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1965,6 +2024,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1997,6 +2059,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2020,11 +2085,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2064,33 +2132,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2099,20 +2177,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2139,6 +2213,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2171,22 +2248,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2210,6 +2285,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2242,6 +2320,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2265,11 +2346,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2309,30 +2393,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2341,20 +2434,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2381,6 +2470,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2413,22 +2505,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2452,6 +2542,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2484,6 +2577,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2507,11 +2603,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2546,25 +2645,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2588,6 +2692,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2620,6 +2727,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2643,11 +2753,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2694,19 +2807,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2754,8 +2872,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/lifts.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/lifts.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/lifts.id.schema.json
+++ b/src/validator/schemas/lifts.id.schema.json
@@ -133,21 +133,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -181,11 +187,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -258,6 +267,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -275,28 +285,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -338,6 +326,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -361,6 +371,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -432,70 +443,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -504,6 +524,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -527,6 +548,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -546,6 +568,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -568,6 +591,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -591,6 +615,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -617,6 +642,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -643,6 +669,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -689,6 +716,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -794,6 +822,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1109,6 +1138,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1152,11 +1182,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1196,30 +1229,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1228,20 +1270,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1268,6 +1306,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1300,22 +1341,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1339,6 +1378,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1371,6 +1413,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1394,11 +1439,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1445,19 +1493,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1505,8 +1558,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1593,11 +1648,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1637,30 +1695,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1669,8 +1736,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1738,18 +1807,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1776,6 +1840,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1808,22 +1875,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1847,6 +1912,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1879,22 +1947,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1918,6 +1984,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1950,22 +2019,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1989,6 +2056,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2021,22 +2091,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2060,6 +2128,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2092,22 +2163,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2131,6 +2200,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2163,6 +2235,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2186,11 +2261,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2230,33 +2308,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2265,20 +2353,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2305,6 +2389,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2337,22 +2424,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2376,6 +2461,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2408,6 +2496,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2431,11 +2522,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2475,30 +2569,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2507,20 +2610,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2547,6 +2646,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2579,22 +2681,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2618,6 +2718,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2650,6 +2753,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/lifts.schema.json
+++ b/src/validator/schemas/lifts.schema.json
@@ -162,21 +162,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -210,11 +216,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -287,6 +296,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -304,28 +314,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -367,6 +355,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -390,6 +400,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -461,70 +472,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -533,6 +553,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -556,6 +577,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -575,6 +597,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -597,6 +620,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -620,6 +644,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -646,6 +671,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -672,6 +698,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -718,6 +745,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -823,6 +851,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1138,6 +1167,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1181,11 +1211,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1225,30 +1258,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1257,20 +1299,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1297,6 +1335,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1329,22 +1370,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1368,6 +1407,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1400,6 +1442,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1423,11 +1468,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1474,19 +1522,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1534,8 +1587,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1622,11 +1677,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1666,30 +1724,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1698,8 +1765,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1767,18 +1836,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1805,6 +1869,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1837,22 +1904,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1876,6 +1941,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1908,22 +1976,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1947,6 +2013,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1979,22 +2048,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2018,6 +2085,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2050,22 +2120,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2089,6 +2157,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2121,22 +2192,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2160,6 +2229,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2192,6 +2264,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2215,11 +2290,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2259,33 +2337,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2294,20 +2382,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2334,6 +2418,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2366,22 +2453,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2405,6 +2490,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2437,6 +2525,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2460,11 +2551,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2504,30 +2598,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2536,20 +2639,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2576,6 +2675,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2608,22 +2710,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2647,6 +2747,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2679,6 +2782,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mediaobjects.id.copyrightowner.schema.json
+++ b/src/validator/schemas/mediaobjects.id.copyrightowner.schema.json
@@ -69,21 +69,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -117,11 +123,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -194,6 +203,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -211,28 +221,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -274,6 +262,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -297,6 +307,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -368,70 +379,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -440,6 +460,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -463,6 +484,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -482,6 +504,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -504,6 +527,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -527,6 +551,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -553,6 +578,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -579,6 +605,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -625,6 +652,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -730,6 +758,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1045,6 +1074,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1088,11 +1118,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1127,25 +1160,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1169,6 +1207,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1201,6 +1242,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1224,11 +1268,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1275,19 +1322,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1335,8 +1387,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/mediaobjects.id.schema.json
+++ b/src/validator/schemas/mediaobjects.id.schema.json
@@ -69,21 +69,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -117,11 +123,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -194,6 +203,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -211,28 +221,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -274,6 +262,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -297,6 +307,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -368,70 +379,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -440,6 +460,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -463,6 +484,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -482,6 +504,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -504,6 +527,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -527,6 +551,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -553,6 +578,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -579,6 +605,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -625,6 +652,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -730,6 +758,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1045,6 +1074,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1088,11 +1118,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1139,19 +1172,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1199,8 +1237,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1287,11 +1327,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1326,25 +1369,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1368,6 +1416,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1400,6 +1451,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mediaobjects.schema.json
+++ b/src/validator/schemas/mediaobjects.schema.json
@@ -98,21 +98,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -146,11 +152,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -223,6 +232,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -240,28 +250,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -303,6 +291,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -326,6 +336,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -397,70 +408,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -469,6 +489,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -492,6 +513,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -511,6 +533,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -533,6 +556,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -556,6 +580,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -582,6 +607,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -608,6 +634,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -654,6 +681,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -759,6 +787,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1074,6 +1103,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1117,11 +1147,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1168,19 +1201,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1228,8 +1266,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1316,11 +1356,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1355,25 +1398,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1397,6 +1445,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1429,6 +1480,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mountainareas.id.areaowner.schema.json
+++ b/src/validator/schemas/mountainareas.id.areaowner.schema.json
@@ -69,21 +69,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -117,11 +123,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -194,6 +203,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -211,28 +221,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -274,6 +262,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -297,6 +307,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -368,70 +379,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -440,6 +460,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -463,6 +484,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -482,6 +504,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -504,6 +527,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -527,6 +551,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -553,6 +578,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -579,6 +605,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -625,6 +652,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -730,6 +758,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1045,6 +1074,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1088,11 +1118,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1127,25 +1160,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1169,6 +1207,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1201,6 +1242,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1224,11 +1268,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1275,19 +1322,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1335,8 +1387,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/mountainareas.id.connections.schema.json
+++ b/src/validator/schemas/mountainareas.id.connections.schema.json
@@ -166,21 +166,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -214,11 +220,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -291,6 +300,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -308,28 +318,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -371,6 +359,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -394,6 +404,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -465,70 +476,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -537,6 +557,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -560,6 +581,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -579,6 +601,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -601,6 +624,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -624,6 +648,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -650,6 +675,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -676,6 +702,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -722,6 +749,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -827,6 +855,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1142,6 +1171,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1185,11 +1215,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1229,30 +1262,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1261,20 +1303,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1301,6 +1339,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1333,22 +1374,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1372,6 +1411,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1404,6 +1446,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1427,11 +1472,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1471,30 +1519,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1503,8 +1560,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1572,18 +1631,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1610,6 +1664,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1642,22 +1699,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1681,6 +1736,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1713,22 +1771,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1752,6 +1808,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1784,22 +1843,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1823,6 +1880,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1855,22 +1915,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1894,6 +1952,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1926,22 +1987,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1965,6 +2024,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1997,6 +2059,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2020,11 +2085,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2064,33 +2132,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2099,20 +2177,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2139,6 +2213,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2171,22 +2248,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2210,6 +2285,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2242,6 +2320,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2265,11 +2346,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2309,30 +2393,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2341,20 +2434,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2381,6 +2470,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2413,22 +2505,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2452,6 +2542,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2484,6 +2577,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2507,11 +2603,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2546,25 +2645,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2588,6 +2692,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2620,6 +2727,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2643,11 +2753,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2694,19 +2807,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2754,8 +2872,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/mountainareas.id.lifts.schema.json
+++ b/src/validator/schemas/mountainareas.id.lifts.schema.json
@@ -141,21 +141,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -189,11 +195,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -266,6 +275,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -283,28 +293,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -346,6 +334,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -369,6 +379,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -440,70 +451,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -512,6 +532,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -535,6 +556,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -554,6 +576,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -576,6 +599,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -599,6 +623,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -625,6 +650,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -651,6 +677,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -697,6 +724,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -802,6 +830,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1117,6 +1146,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1160,11 +1190,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1204,30 +1237,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1236,20 +1278,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1276,6 +1314,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1308,22 +1349,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1347,6 +1386,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1379,6 +1421,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1402,11 +1447,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1453,19 +1501,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1513,8 +1566,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1601,11 +1656,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1645,30 +1703,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1677,8 +1744,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1746,18 +1815,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1784,6 +1848,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1816,22 +1883,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1855,6 +1920,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1887,22 +1955,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1926,6 +1992,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1958,22 +2027,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1997,6 +2064,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2029,22 +2099,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2068,6 +2136,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2100,22 +2171,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2139,6 +2208,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2171,6 +2243,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2194,11 +2269,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2238,33 +2316,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2273,20 +2361,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2313,6 +2397,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2345,22 +2432,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2384,6 +2469,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2416,6 +2504,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2439,11 +2530,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2483,30 +2577,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2515,20 +2618,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2555,6 +2654,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2587,22 +2689,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2626,6 +2726,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2658,6 +2761,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mountainareas.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/mountainareas.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mountainareas.id.schema.json
+++ b/src/validator/schemas/mountainareas.id.schema.json
@@ -149,21 +149,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -197,11 +203,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -274,6 +283,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -291,28 +301,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -354,6 +342,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -377,6 +387,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -448,70 +459,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -520,6 +540,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -543,6 +564,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -562,6 +584,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -584,6 +607,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -607,6 +631,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -633,6 +658,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -659,6 +685,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -705,6 +732,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -810,6 +838,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1125,6 +1154,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1168,11 +1198,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1212,30 +1245,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1244,8 +1286,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1313,18 +1357,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1351,6 +1390,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1383,22 +1425,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1422,6 +1462,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1454,22 +1497,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1493,6 +1534,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1525,22 +1569,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1564,6 +1606,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1596,22 +1641,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1635,6 +1678,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1667,22 +1713,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1706,6 +1750,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1738,6 +1785,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1761,11 +1811,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1800,25 +1853,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1842,6 +1900,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1874,6 +1935,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1897,11 +1961,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1941,30 +2008,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1973,20 +2049,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2013,6 +2085,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2045,22 +2120,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2084,6 +2157,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2116,6 +2192,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2139,11 +2218,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2190,19 +2272,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2250,8 +2337,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2338,11 +2427,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2382,33 +2474,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2417,20 +2519,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2457,6 +2555,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2489,22 +2590,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2528,6 +2627,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2560,6 +2662,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2583,11 +2688,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2627,30 +2735,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2659,20 +2776,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2699,6 +2812,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2731,22 +2847,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2770,6 +2884,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2802,6 +2919,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mountainareas.id.snowparks.schema.json
+++ b/src/validator/schemas/mountainareas.id.snowparks.schema.json
@@ -141,21 +141,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -189,11 +195,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -266,6 +275,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -283,28 +293,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -346,6 +334,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -369,6 +379,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -440,70 +451,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -512,6 +532,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -535,6 +556,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -554,6 +576,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -576,6 +599,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -599,6 +623,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -625,6 +650,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -651,6 +677,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -697,6 +724,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -802,6 +830,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1117,6 +1146,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1160,11 +1190,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1204,33 +1237,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -1239,20 +1282,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1279,6 +1318,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1311,22 +1353,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1350,6 +1390,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1382,6 +1425,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1405,11 +1451,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1449,30 +1498,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1481,20 +1539,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1521,6 +1575,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1553,22 +1610,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1592,6 +1647,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1624,6 +1682,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1647,11 +1708,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1698,19 +1762,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1758,8 +1827,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1846,11 +1917,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1890,30 +1964,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1922,8 +2005,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1991,18 +2076,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2029,6 +2109,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2061,22 +2144,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2100,6 +2181,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2132,22 +2216,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2171,6 +2253,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2203,22 +2288,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2242,6 +2325,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2274,22 +2360,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2313,6 +2397,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2345,22 +2432,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2384,6 +2469,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2416,6 +2504,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2439,11 +2530,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2483,30 +2577,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2515,20 +2618,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2555,6 +2654,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2587,22 +2689,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2626,6 +2726,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2658,6 +2761,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mountainareas.id.subareas.schema.json
+++ b/src/validator/schemas/mountainareas.id.subareas.schema.json
@@ -157,21 +157,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -205,11 +211,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -282,6 +291,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -299,28 +309,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -362,6 +350,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -385,6 +395,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -456,70 +467,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -528,6 +548,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -551,6 +572,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -570,6 +592,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -592,6 +615,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -615,6 +639,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -641,6 +666,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -667,6 +693,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -713,6 +740,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -818,6 +846,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1133,6 +1162,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1176,11 +1206,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1220,30 +1253,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1252,8 +1294,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1321,18 +1365,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1359,6 +1398,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1391,22 +1433,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1430,6 +1470,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1462,22 +1505,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1501,6 +1542,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1533,22 +1577,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1572,6 +1614,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1604,22 +1649,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1643,6 +1686,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1675,22 +1721,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1714,6 +1758,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1746,6 +1793,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1769,11 +1819,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1808,25 +1861,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1850,6 +1908,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1882,6 +1943,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1905,11 +1969,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1949,30 +2016,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1981,20 +2057,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2021,6 +2093,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2053,22 +2128,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2092,6 +2165,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2124,6 +2200,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2147,11 +2226,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2198,19 +2280,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2258,8 +2345,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2346,11 +2435,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2390,33 +2482,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2425,20 +2527,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2465,6 +2563,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2497,22 +2598,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2536,6 +2635,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2568,6 +2670,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2591,11 +2696,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2635,30 +2743,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2667,20 +2784,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2707,6 +2820,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2739,22 +2855,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2778,6 +2892,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2810,6 +2927,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mountainareas.id.trails.schema.json
+++ b/src/validator/schemas/mountainareas.id.trails.schema.json
@@ -141,21 +141,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -189,11 +195,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -266,6 +275,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -283,28 +293,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -346,6 +334,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -369,6 +379,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -440,70 +451,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -512,6 +532,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -535,6 +556,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -554,6 +576,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -576,6 +599,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -599,6 +623,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -625,6 +650,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -651,6 +677,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -697,6 +724,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -802,6 +830,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1117,6 +1146,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1160,11 +1190,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1204,30 +1237,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -1236,20 +1278,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1276,6 +1314,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1308,22 +1349,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1347,6 +1386,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1379,6 +1421,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1402,11 +1447,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1446,30 +1494,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1478,20 +1535,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1518,6 +1571,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1550,22 +1606,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1589,6 +1643,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1621,6 +1678,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1644,11 +1704,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1695,19 +1758,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1755,8 +1823,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1843,11 +1913,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1887,30 +1960,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1919,8 +2001,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1988,18 +2072,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2026,6 +2105,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2058,22 +2140,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2097,6 +2177,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2129,22 +2212,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2168,6 +2249,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2200,22 +2284,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2239,6 +2321,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2271,22 +2356,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2310,6 +2393,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2342,22 +2428,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2381,6 +2465,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2413,6 +2500,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2436,11 +2526,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2480,33 +2573,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2515,20 +2618,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2555,6 +2654,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2587,22 +2689,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2626,6 +2726,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2658,6 +2761,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/mountainareas.schema.json
+++ b/src/validator/schemas/mountainareas.schema.json
@@ -178,21 +178,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -226,11 +232,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -303,6 +312,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -320,28 +330,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -383,6 +371,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -406,6 +416,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -477,70 +488,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -549,6 +569,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -572,6 +593,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -591,6 +613,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -613,6 +636,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -636,6 +660,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -662,6 +687,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -688,6 +714,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -734,6 +761,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -839,6 +867,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1154,6 +1183,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1197,11 +1227,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1241,30 +1274,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1273,8 +1315,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1342,18 +1386,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1380,6 +1419,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1412,22 +1454,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1451,6 +1491,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1483,22 +1526,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1522,6 +1563,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1554,22 +1598,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1593,6 +1635,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1625,22 +1670,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1664,6 +1707,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1696,22 +1742,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1735,6 +1779,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1767,6 +1814,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1790,11 +1840,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1829,25 +1882,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1871,6 +1929,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1903,6 +1964,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1926,11 +1990,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1970,30 +2037,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -2002,20 +2078,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2042,6 +2114,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2074,22 +2149,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2113,6 +2186,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2145,6 +2221,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2168,11 +2247,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2219,19 +2301,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2279,8 +2366,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2367,11 +2456,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2411,33 +2503,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2446,20 +2548,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2486,6 +2584,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2518,22 +2619,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2557,6 +2656,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2589,6 +2691,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2612,11 +2717,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2656,30 +2764,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2688,20 +2805,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2728,6 +2841,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2760,22 +2876,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2799,6 +2913,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2831,6 +2948,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/snowparks.id.connections.schema.json
+++ b/src/validator/schemas/snowparks.id.connections.schema.json
@@ -166,21 +166,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -214,11 +220,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -291,6 +300,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -308,28 +318,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -371,6 +359,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -394,6 +404,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -465,70 +476,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -537,6 +557,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -560,6 +581,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -579,6 +601,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -601,6 +624,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -624,6 +648,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -650,6 +675,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -676,6 +702,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -722,6 +749,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -827,6 +855,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1142,6 +1171,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1185,11 +1215,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1229,30 +1262,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1261,20 +1303,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1301,6 +1339,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1333,22 +1374,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1372,6 +1411,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1404,6 +1446,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1427,11 +1472,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1471,30 +1519,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1503,8 +1560,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1572,18 +1631,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1610,6 +1664,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1642,22 +1699,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1681,6 +1736,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1713,22 +1771,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1752,6 +1808,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1784,22 +1843,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1823,6 +1880,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1855,22 +1915,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1894,6 +1952,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1926,22 +1987,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1965,6 +2024,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1997,6 +2059,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2020,11 +2085,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2064,33 +2132,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2099,20 +2177,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2139,6 +2213,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2171,22 +2248,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2210,6 +2285,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2242,6 +2320,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2265,11 +2346,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2309,30 +2393,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2341,20 +2434,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2381,6 +2470,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2413,22 +2505,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2452,6 +2542,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2484,6 +2577,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2507,11 +2603,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2546,25 +2645,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2588,6 +2692,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2620,6 +2727,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2643,11 +2753,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2694,19 +2807,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2754,8 +2872,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/snowparks.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/snowparks.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/snowparks.id.schema.json
+++ b/src/validator/schemas/snowparks.id.schema.json
@@ -133,21 +133,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -181,11 +187,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -258,6 +267,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -275,28 +285,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -338,6 +326,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -361,6 +371,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -432,70 +443,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -504,6 +524,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -527,6 +548,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -546,6 +568,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -568,6 +591,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -591,6 +615,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -617,6 +642,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -643,6 +669,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -689,6 +716,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -794,6 +822,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1109,6 +1138,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1152,11 +1182,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1196,33 +1229,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -1231,20 +1274,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1271,6 +1310,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1303,22 +1345,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1342,6 +1382,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1374,6 +1417,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1397,11 +1443,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1441,30 +1490,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1473,20 +1531,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1513,6 +1567,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1545,22 +1602,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1584,6 +1639,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1616,6 +1674,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1639,11 +1700,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1690,19 +1754,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1750,8 +1819,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1838,11 +1909,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1882,30 +1956,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1914,8 +1997,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1983,18 +2068,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2021,6 +2101,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2053,22 +2136,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2092,6 +2173,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2124,22 +2208,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2163,6 +2245,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2195,22 +2280,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2234,6 +2317,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2266,22 +2352,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2305,6 +2389,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2337,22 +2424,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2376,6 +2461,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2408,6 +2496,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2431,11 +2522,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2475,30 +2569,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2507,20 +2610,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2547,6 +2646,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2579,22 +2681,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2618,6 +2718,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2650,6 +2753,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/snowparks.schema.json
+++ b/src/validator/schemas/snowparks.schema.json
@@ -162,21 +162,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -210,11 +216,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -287,6 +296,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -304,28 +314,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -367,6 +355,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -390,6 +400,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -461,70 +472,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -533,6 +553,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -556,6 +577,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -575,6 +597,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -597,6 +620,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -620,6 +644,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -646,6 +671,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -672,6 +698,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -718,6 +745,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -823,6 +851,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1138,6 +1167,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1181,11 +1211,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1225,33 +1258,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -1260,20 +1303,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1300,6 +1339,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1332,22 +1374,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1371,6 +1411,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1403,6 +1446,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1426,11 +1472,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1470,30 +1519,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1502,20 +1560,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1542,6 +1596,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1574,22 +1631,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1613,6 +1668,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1645,6 +1703,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1668,11 +1729,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1719,19 +1783,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1779,8 +1848,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1867,11 +1938,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1911,30 +1985,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1943,8 +2026,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2012,18 +2097,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2050,6 +2130,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2082,22 +2165,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2121,6 +2202,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2153,22 +2237,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2192,6 +2274,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2224,22 +2309,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2263,6 +2346,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2295,22 +2381,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2334,6 +2418,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2366,22 +2453,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2405,6 +2490,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2437,6 +2525,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2460,11 +2551,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2504,30 +2598,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2536,20 +2639,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2576,6 +2675,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2608,22 +2710,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2647,6 +2747,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2679,6 +2782,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/trails.id.connections.schema.json
+++ b/src/validator/schemas/trails.id.connections.schema.json
@@ -166,21 +166,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -214,11 +220,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -291,6 +300,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -308,28 +318,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -371,6 +359,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -394,6 +404,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -465,70 +476,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -537,6 +557,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -560,6 +581,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -579,6 +601,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -601,6 +624,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -624,6 +648,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -650,6 +675,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -676,6 +702,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -722,6 +749,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -827,6 +855,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1142,6 +1171,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1185,11 +1215,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1229,30 +1262,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1261,20 +1303,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1301,6 +1339,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1333,22 +1374,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1372,6 +1411,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1404,6 +1446,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1427,11 +1472,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1471,30 +1519,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1503,8 +1560,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1572,18 +1631,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1610,6 +1664,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1642,22 +1699,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1681,6 +1736,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1713,22 +1771,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1752,6 +1808,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1784,22 +1843,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1823,6 +1880,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1855,22 +1915,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1894,6 +1952,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1926,22 +1987,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1965,6 +2024,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1997,6 +2059,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2020,11 +2085,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2064,33 +2132,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2099,20 +2177,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2139,6 +2213,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2171,22 +2248,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2210,6 +2285,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2242,6 +2320,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2265,11 +2346,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2309,30 +2393,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2341,20 +2434,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2381,6 +2470,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2413,22 +2505,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2452,6 +2542,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2484,6 +2577,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2507,11 +2603,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2546,25 +2645,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2588,6 +2692,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2620,6 +2727,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2643,11 +2753,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2694,19 +2807,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -2754,8 +2872,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/trails.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/trails.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/trails.id.schema.json
+++ b/src/validator/schemas/trails.id.schema.json
@@ -133,21 +133,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -181,11 +187,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -258,6 +267,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -275,28 +285,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -338,6 +326,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -361,6 +371,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -432,70 +443,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -504,6 +524,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -527,6 +548,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -546,6 +568,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -568,6 +591,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -591,6 +615,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -617,6 +642,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -643,6 +669,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -689,6 +716,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -794,6 +822,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1109,6 +1138,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1152,11 +1182,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1196,30 +1229,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -1228,20 +1270,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1268,6 +1306,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1300,22 +1341,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1339,6 +1378,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1371,6 +1413,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1394,11 +1439,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1438,30 +1486,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1470,20 +1527,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1510,6 +1563,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1542,22 +1598,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1581,6 +1635,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1613,6 +1670,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1636,11 +1696,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1687,19 +1750,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1747,8 +1815,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1835,11 +1905,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1879,30 +1952,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1911,8 +1993,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1980,18 +2064,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2018,6 +2097,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2050,22 +2132,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2089,6 +2169,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2121,22 +2204,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2160,6 +2241,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2192,22 +2276,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2231,6 +2313,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2263,22 +2348,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2302,6 +2385,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2334,22 +2420,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2373,6 +2457,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2405,6 +2492,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2428,11 +2518,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2472,33 +2565,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2507,20 +2610,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2547,6 +2646,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2579,22 +2681,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2618,6 +2718,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2650,6 +2753,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/trails.schema.json
+++ b/src/validator/schemas/trails.schema.json
@@ -162,21 +162,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -210,11 +216,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -287,6 +296,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -304,28 +314,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -367,6 +355,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -390,6 +400,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -461,70 +472,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -533,6 +553,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -556,6 +577,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -575,6 +597,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -597,6 +620,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -620,6 +644,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -646,6 +671,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -672,6 +698,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -718,6 +745,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -823,6 +851,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1138,6 +1167,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1181,11 +1211,14 @@
     },
     "trails": {
       "type": "object",
+      "description": "A resource representing a trail, a physical path that supports the practice of some type of sport activity.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "trails"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1225,30 +1258,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the trail.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "An object containing the difficulty level of a ski slope.",
                   "$ref": "#/definitions/trailDifficulty"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the trail in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the trail.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the trail in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the trail in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the trail is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the trail.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -1257,20 +1299,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the trail, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1297,6 +1335,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1329,22 +1370,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the trail.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1368,6 +1407,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1400,6 +1442,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1423,11 +1468,14 @@
     },
     "lifts": {
       "type": "object",
+      "description": "A resource representing a lift, a machine designed to transport people uphill, being often used to transport skiers in mountain areas.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "lifts"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1467,30 +1515,39 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the lift.",
                   "$ref": "#/definitions/address"
                 },
                 "capacity": {
+                  "description": "A number representing how many persons the lift can transport hourly on average.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the lift in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the lift.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the lift in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the lift in meters above sea level.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the lift is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "personsPerChair": {
+                  "description": "An integer representing the number of persons that fit in a single chair/cabin of a lift.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1499,20 +1556,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the lift, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1539,6 +1592,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1571,22 +1627,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the lifts.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1610,6 +1664,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1642,6 +1699,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1665,11 +1725,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1716,19 +1779,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1776,8 +1844,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1864,11 +1934,14 @@
     },
     "mountainAreas": {
       "type": "object",
+      "description": "A resource representing a mountain area, a geographical region in which alpine sports and activities can be performed, such as skiing, snowboarding, climbing, and hiking.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mountainAreas"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1908,30 +1981,39 @@
               "type": "object",
               "properties": {
                 "area": {
+                  "description": "A number representing the total area, in square meters, of the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the mountain area in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the mountain area.",
                   "$ref": "#/definitions/text"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the mountain area in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the mountain area is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the mountain area.",
                   "$ref": "#/definitions/snowCondition"
                 },
                 "totalParkLength": {
+                  "description": "An integer representing the total length, in meters, of all snowparks located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "totalTrailLength": {
+                  "description": "An integer representing the total length, in meters, of all trails located within the mountain area.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               }
@@ -1940,8 +2022,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "areaOwner": {
+              "description": "An object representing references to an agent resource who owns the mountain area.",
               "oneOf": [
                 {
                   "type": "object",
@@ -2009,18 +2093,13 @@
               ]
             },
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the mountain area, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2047,6 +2126,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2079,22 +2161,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "lifts": {
+              "description": "An object representing references to lift resources that identify the lifts located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2118,6 +2198,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2150,22 +2233,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2189,6 +2270,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2221,22 +2305,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "snowparks": {
+              "description": "An object representing references to snowpark resources that identify the snowparks located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2260,6 +2342,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2292,22 +2377,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "subAreas": {
+              "description": "An object representing references to mountain area resources that identify the mountain areas located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2331,6 +2414,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2363,22 +2449,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "trails": {
+              "description": "An object representing references to trail resources that identify the trails located within the mountain area.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2402,6 +2486,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2434,6 +2521,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -2457,11 +2547,14 @@
     },
     "snowparks": {
       "type": "object",
+      "description": "A resource representing a snowpark, a particular type of trail that is designed to allow skiers and snowboarders to perform free-style tricks by providing them with special features, such as jumps and rails. ",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "snowparks"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -2501,33 +2594,43 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the snowpark.",
                   "$ref": "#/definitions/address"
                 },
                 "difficulty": {
+                  "description": "A string describing the difficulty level of a snowpark.",
                   "$ref": "#/definitions/snowparkDifficulty"
                 },
                 "features": {
+                  "description": "An array of category strings that informs the types of features available within the snowpark, such as a jump or a rail.",
                   "$ref": "#/definitions/categories"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the snowpark in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the snowpark.",
                   "$ref": "#/definitions/text"
                 },
                 "length": {
+                  "description": "A number representing the length of the snowpark in meters.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "maxAltitude": {
+                  "description": "A number representing the highest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "minAltitude": {
+                  "description": "A number representing the lowest elevation point of the snowpark in meters above sea level.",
                   "$ref": "#/definitions/optionalPositiveInteger"
                 },
                 "openingHours": {
+                  "description": "An array of hours specification objects representing the hours in which the snowpark is open to the public.",
                   "$ref": "#/definitions/hoursSpecifications"
                 },
                 "snowCondition": {
+                  "description": "A snow condition object containing the latest reported condition of the snow in the snowpark.",
                   "$ref": "#/definitions/snowCondition"
                 }
               }
@@ -2536,20 +2639,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "connections": {
+              "description": "An object representing references to place resources that identify the places that are physically accessible from the snowpark, which may include mountain areas, other lifts, snowparks, and trails.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2576,6 +2675,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2608,22 +2710,20 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             },
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the snowpark.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -2647,6 +2747,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -2679,6 +2782,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/venues.id.multimediadescriptions.schema.json
+++ b/src/validator/schemas/venues.id.multimediadescriptions.schema.json
@@ -77,21 +77,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -125,11 +131,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -202,6 +211,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -219,28 +229,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -282,6 +270,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -305,6 +315,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -376,70 +387,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -448,6 +468,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -471,6 +492,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -490,6 +512,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -512,6 +535,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -535,6 +559,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -561,6 +586,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -587,6 +613,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -633,6 +660,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -738,6 +766,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1053,6 +1082,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1096,11 +1126,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1147,19 +1180,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1207,8 +1245,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",
@@ -1295,11 +1335,14 @@
     },
     "agents": {
       "type": "object",
+      "description": "A resource representing an individual who bears mental attitudes and is capable of performing actions and perceiving events.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "agents"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1334,25 +1377,30 @@
                   "type": "object"
                 }
               }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contactPoints": {
+                  "description": "An array of contact point objects.",
+                  "$ref": "#/definitions/contactPoints"
+                }
+              }
             }
           ]
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the agent.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1376,6 +1424,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1408,6 +1459,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }

--- a/src/validator/schemas/venues.id.schema.json
+++ b/src/validator/schemas/venues.id.schema.json
@@ -69,21 +69,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -117,11 +123,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -194,6 +203,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -211,28 +221,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -274,6 +262,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -297,6 +307,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -368,70 +379,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -440,6 +460,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -463,6 +484,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -482,6 +504,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -504,6 +527,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -527,6 +551,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -553,6 +578,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -579,6 +605,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -625,6 +652,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -730,6 +758,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1045,6 +1074,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1088,11 +1118,14 @@
     },
     "venues": {
       "type": "object",
+      "description": "A resource representing a venue, a place that may host an event.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "venues"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1132,12 +1165,15 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the venue.",
                   "$ref": "#/definitions/address"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the venue in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the venue.",
                   "$ref": "#/definitions/text"
                 }
               }
@@ -1146,20 +1182,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the venue.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1183,6 +1215,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1215,6 +1250,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1238,11 +1276,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1289,19 +1330,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1349,8 +1395,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",

--- a/src/validator/schemas/venues.schema.json
+++ b/src/validator/schemas/venues.schema.json
@@ -98,21 +98,27 @@
       "type": "object",
       "properties": {
         "abstract": {
+          "description": "A text object containing a short textual description of the resource.",
           "$ref": "#/definitions/abstract"
         },
         "categories": {
+          "description": "An array of category strings identifying the types instantiated by the resource.",
           "$ref": "#/definitions/categories"
         },
         "description": {
+          "description": "A text object containing the complete textual description of the resource.",
           "$ref": "#/definitions/description"
         },
         "name": {
+          "description": "A text object containing the complete name of the resource.",
           "$ref": "#/definitions/name"
         },
         "shortName": {
+          "description": "A text object containing a short name of the resource.",
           "$ref": "#/definitions/shortName"
         },
         "url": {
+          "description": "A url string or a multilingual url object containing language-specific url strings.",
           "$ref": "#/definitions/url"
         }
       }
@@ -146,11 +152,14 @@
     },
     "basicMeta": {
       "type": "object",
+      "description": "An object containing metadata of the resource (e.g., the URL representing the resource's data provider or a date-time string of the instant of the resource's last update).",
       "properties": {
         "dataProvider": {
+          "description": "A url string that identifies the organization responsible for the data about a resource and who can be contacted in case of questions or issues regarding it.",
           "$ref": "#/definitions/dataProvider"
         },
         "lastUpdate": {
+          "description": "A date-time string that identifies when a resource was last modified in the server.",
           "$ref": "#/definitions/lastUpdate"
         }
       },
@@ -223,6 +232,7 @@
       }
     },
     "links": {
+      "description": "An object containing the links related to access related resources (e.g., a link to the agent resources representing organizers and sponsors of an event, a link to the media object resources representing multimedia descriptions of a mountain area resource, or a link to the resource itself, also referred to as `self`).",
       "oneOf": [
         {
           "type": "null"
@@ -240,28 +250,6 @@
               }
             ]
           }
-        }
-      ]
-    },
-    "relationshipToMany": {
-      "oneOf": [
-        {
-          "type": "null"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "$ref": "#/definitions/referenceArray"
-            },
-            "links": {
-              "$ref": "#/definitions/links"
-            }
-          },
-          "required": [
-            "data",
-            "links"
-          ]
         }
       ]
     },
@@ -303,6 +291,28 @@
         }
       ]
     },
+    "relationshipToMany": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/referenceArray"
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            }
+          },
+          "required": [
+            "data",
+            "links"
+          ]
+        }
+      ]
+    },
     "relationshipToOne": {
       "oneOf": [
         {
@@ -326,6 +336,7 @@
       ]
     },
     "address": {
+      "description": "An object that represents an address.",
       "oneOf": [
         {
           "type": "null"
@@ -397,70 +408,79 @@
       ]
     },
     "contactPoint": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "availableHours": {
+          "$ref": "#/definitions/hoursSpecifications"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "telephone": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "string",
+              "minLength": 1
+            }
+          ]
+        }
+      },
+      "required": [
+        "address",
+        "availableHours",
+        "email",
+        "telephone"
+      ],
+      "anyOf": [
+        {
+          "not": {
+            "properties": {
+              "address": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "email": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "not": {
+            "properties": {
+              "telephone": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "contactPoints": {
+      "description": "A contact point array contains data that one can use to contact an agent resource.",
       "oneOf": [
         {
           "type": "null"
         },
         {
-          "type": "object",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/address"
-            },
-            "availableHours": {
-              "$ref": "#/definitions/hoursSpecifications"
-            },
-            "email": {
-              "type": "string",
-              "format": "email"
-            },
-            "telephone": {
-              "oneOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "string",
-                  "minLength": 1
-                }
-              ]
-            }
-          },
-          "required": [
-            "address",
-            "availableHours",
-            "email",
-            "telephone"
-          ],
-          "anyOf": [
-            {
-              "not": {
-                "properties": {
-                  "address": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "email": {
-                    "type": "null"
-                  }
-                }
-              }
-            },
-            {
-              "not": {
-                "properties": {
-                  "telephone": {
-                    "type": "null"
-                  }
-                }
-              }
-            }
-          ]
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/contactPoint"
+          }
         }
       ]
     },
@@ -469,6 +489,7 @@
       "pattern": "[A-Z]{2}"
     },
     "geometry": {
+      "description": "The representation of geographic data structures in this standard is borrowed from the GeoJSON standard specification.",
       "oneOf": [
         {
           "$ref": "#/definitions/geometryPoint"
@@ -492,6 +513,7 @@
     },
     "geometryPoint": {
       "type": "object",
+      "description": "The coordinates member is a single position.",
       "properties": {
         "type": {
           "const": "Point"
@@ -511,6 +533,7 @@
     },
     "geometryMultiPoint": {
       "type": "object",
+      "description": "The coordinates member is an array of positions.",
       "properties": {
         "type": {
           "const": "MultiPoint"
@@ -533,6 +556,7 @@
     },
     "geometryLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of two or more positions.",
       "properties": {
         "type": {
           "const": "LineString"
@@ -556,6 +580,7 @@
     },
     "geometryMultiLineString": {
       "type": "object",
+      "description": "The coordinates member is an array of LineString coordinate arrays.",
       "properties": {
         "type": {
           "const": "MultiLineString"
@@ -582,6 +607,7 @@
     },
     "geometryPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array different coordinate arrays forming a polygon.",
       "properties": {
         "type": {
           "const": "Polygon"
@@ -608,6 +634,7 @@
     },
     "geometryMultiPolygon": {
       "type": "object",
+      "description": "The coordinates member is an array of Polygon coordinate arrays",
       "properties": {
         "type": {
           "const": "MultiPolygon"
@@ -654,6 +681,7 @@
       "pattern": "[a-z]{3}"
     },
     "snowCondition": {
+      "description": "A snow condition object allows the representation of the conditions of a trail, snowpark or a mountain area at a given moment in time.",
       "oneOf": [
         {
           "type": "null"
@@ -759,6 +787,7 @@
       ]
     },
     "text": {
+      "description": "An object that allows exchange of textual data (e.g. name, description) using multiple languages.",
       "oneOf": [
         {
           "type": "null"
@@ -1074,6 +1103,7 @@
       "additionalProperties": false
     },
     "hoursSpecifications": {
+      "description": "An hours specification object allows the representations of schedules over periods of time.",
       "oneOf": [
         {
           "type": "null"
@@ -1117,11 +1147,14 @@
     },
     "venues": {
       "type": "object",
+      "description": "A resource representing a venue, a place that may host an event.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "venues"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1161,12 +1194,15 @@
               "type": "object",
               "properties": {
                 "address": {
+                  "description": "An address object representing the address of the venue.",
                   "$ref": "#/definitions/address"
                 },
                 "geometries": {
+                  "description": "An array of geometry objects each of which represents the location of the venue in terms of GPS coordinates.",
                   "$ref": "#/definitions/optionalGeometries"
                 },
                 "howToArrive": {
+                  "description": "A text object containing instructions on how to arrive at the venue.",
                   "$ref": "#/definitions/text"
                 }
               }
@@ -1175,20 +1211,16 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "multimediaDescriptions": {
+              "description": "An object representing a reference towards media objects that describe the venue.",
               "oneOf": [
-                {
-                  "type": "null"
-                },
                 {
                   "type": "object",
                   "properties": {
                     "data": {
                       "oneOf": [
-                        {
-                          "type": "null"
-                        },
                         {
                           "type": "array",
                           "minItems": 1,
@@ -1212,6 +1244,9 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        {
+                          "type": "null"
                         }
                       ]
                     },
@@ -1244,6 +1279,9 @@
                     "data",
                     "links"
                   ]
+                },
+                {
+                  "type": "null"
                 }
               ]
             }
@@ -1267,11 +1305,14 @@
     },
     "mediaObjects": {
       "type": "object",
+      "description": "A resource representing an object that materializes creative works into a digital format to enable processing and sharing.",
       "properties": {
         "type": {
+          "description": "A string that identifies the resource's type.",
           "const": "mediaObjects"
         },
         "id": {
+          "description": "A string that uniquely and persistently identifies the resource within a server.",
           "type": "string",
           "minLength": 1
         },
@@ -1318,19 +1359,24 @@
               "type": "object",
               "properties": {
                 "contentType": {
+                  "description": "A string that represents the media type (formerly known as MIME type) of the media object.",
                   "type": "string",
                   "pattern": "^(application|audio|font|example|image|message|model|multipart|text|video)/[a-zA-Z0-9-.+]+$"
                 },
                 "duration": {
+                  "description": "A number representing the duration of an audio or a video in seconds.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "height": {
+                  "description": "A number representing the height of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 },
                 "license": {
+                  "description": "A string that represents the license applied to the media object.",
                   "$ref": "#/definitions/optionalNonEmptyString"
                 },
                 "width": {
+                  "description": "A number representing the width of an image or a video in pixels.",
                   "$ref": "#/definitions/optionalNonZeroPositiveInteger"
                 }
               },
@@ -1378,8 +1424,10 @@
         },
         "relationships": {
           "type": "object",
+          "description": "An object containing the resource's data referring to other resources (e.g. the organizers of an event, the trails within a mountain area).",
           "properties": {
             "copyrightOwner": {
+              "description": "An object representing a reference towards an agent resource who owns the rights over the media object.",
               "oneOf": [
                 {
                   "type": "object",


### PR DESCRIPTION
This PR fixes a bug in the server that was causing it to add an address field to mountain areas.

To test, run the server and check the following routes:

- `/1.0/mountainAreas`
- `/1.0/mountainAreas/:id`

I also updated the schemas files, which are now properly documented. Check the description fields and the [src/validator/schemas](src/validator/schemas) folder.